### PR TITLE
Change  '__getitem__' function in DepthDataset class

### DIFF
--- a/UtilityTest.py
+++ b/UtilityTest.py
@@ -27,7 +27,7 @@ class DepthDataset(Dataset):
 
     def __getitem__(self, idx):
         
-        img_name = os.path.join(self.root_dir,os.listdir(self.root_dir)[idx])
+        img_name = os.path.join(self.root_dir,sorted(os.listdir(self.root_dir))[idx])
         image = (Image.open(img_name))
 
         sample1={'image': image}


### PR DESCRIPTION
Hi! I'm using your great code.  
I have a suggestion about `__getitem__ ` function in `DepthDataset` class in `UtilityTest.py`.  

I just execute the `test_img.ipynb` and I got a lot of depth prediction images.  
In my case, It is important to get ordered data to match with input RGB images.  
However, when I use these images, the order is different from the input images!  

So, I just add `sorted()` function, to make the output in the same order as the input image list.  

I think it is more helpful when you just add this function!

Thanks.


